### PR TITLE
M2: Export jar to proj. root, hardcode classpath

### DIFF
--- a/aadams80.gradle
+++ b/aadams80.gradle
@@ -1,13 +1,15 @@
 apply plugin: 'java'
 
+def classPath = 'lib/resources.jar'
+
 dependencies {
-    compile files('lib/resources.jar')
+    compile files(classPath)
 }
 
 jar {
+    destinationDir = file('.')
     manifest {
         attributes 'Main-Class': 'edu.gatech.oad.antlab.pkg1.AntLabMain',
-                   // Inspired heavily by http://stackoverflow.com/a/22759572/321301
-                   'Class-Path': configurations.compile.collect{it.getPath()}.join(' ')
+                   'Class-Path': classPath
     }
 }


### PR DESCRIPTION
Currently, I use a scary closure I found on StackOverflow to put the
absolute path of resources.jar into the jar mainfest's classpath.
Instead, re-use the compilation classpath, which has a relative path to
resources.jar. And make the classpath point to the right place by
writing the built jar to the project root rather than build/lib.
